### PR TITLE
Taking master of mbed-clitest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,14 +120,11 @@ def run_smoke(target_families, raasPort, suite_to_run, toolchains, targets) {
         deleteDir()
         dir("mbed-clitest") {
           git "git@github.com:ARMmbed/mbed-clitest.git"
-          execute("git checkout ${env.LATEST_CLITEST_REL}")
+          execute("git checkout master")
           execute("git submodule update --init --recursive testcases")
 
           dir("testcases") {
-            execute("git checkout master")
-            dir("cellular") {
-              execute("git checkout master")
-            }
+            execute("git all checkout master")
           }
         
     for (int i = 0; i < target_families.size(); i++) {


### PR DESCRIPTION
Temporarily taking master of mbed-clitest rather than release version.
We need to get cellular-suite submodule which will be added to the next
relased version.