### PR TITLE
Taking master of mbed-clitest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 properties ([[$class: 'ParametersDefinitionProperty', parameterDefinitions: [
   [$class: 'StringParameterDefinition', name: 'mbed_os_revision', defaultValue: 'mbed-os-5.4', description: 'Revision of mbed-os to build'],
-  [$class: 'BooleanParameterDefinition', name: 'smoke_test', defaultValue: false, description: 'Runs HW smoke tests on Cellular devices']
+  [$class: 'BooleanParameterDefinition', name: 'smoke_test', defaultValue: true, description: 'Runs HW smoke tests on Cellular devices']
   ]]])
 
 echo "Run smoke tests: ${params.smoke_test}"
@@ -122,8 +122,10 @@ def run_smoke(target_families, raasPort, suite_to_run, toolchains, targets) {
           git "git@github.com:ARMmbed/mbed-clitest.git"
           execute("git checkout master")
           execute("git submodule update --init --recursive testcases")
-
+          
           dir("testcases") {
+            execute("git all checkout master")
+            execute("git submodule update --init --recursive cellular")
             execute("git all checkout master")
           }
         


### PR DESCRIPTION
Temporarily taking master of mbed-clitest rather than release version.
We need to get cellular-suite submodule which will be added to the next
relased version.