### PR TITLE
Updating mbed-os pointer to master

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#fa82a783a893084c6767aee5818484728f42f009
+https://github.com/ARMmbed/mbed-os/#22b183a42b4ccba9c21549fdf5800e090fb6fda1


### PR DESCRIPTION
mbed-os pointer to updated to point to master
SHA 22b183a42b4ccba9c21549fdf5800e090fb6fda1.
At this tip, memory optimizations to LWIP were
taken in from PR #4911.
The PR #4911 saves several Ks of RAM by putting
some LWIP structures on the ethernet/usb ram regions
for IAR compiler. This enables us to fit into UBLOX_C027
platform without any linker file modification.