### PR TITLE
Updating mbed-os to mbed-os-5.6.0

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#fa82a783a893084c6767aee5818484728f42f009
+https://github.com/ARMmbed/mbed-os/#5499db1e815b035c2039b6f1e7cbcbf1fd7e0f19


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.6.0 . 