### PR TITLE
Disabled new targets until 5.9 is out

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,9 +26,9 @@ def raas = [
 def targets = [
   "UBLOX_C027",
   "MTB_MTS_DRAGONFLY",
-  "UBLOX_C030_U201",
-  "MTB_ADV_WISE_1570",
-  "K64F"
+  "UBLOX_C030_U201"
+  //"MTB_ADV_WISE_1570",
+  //"K64F"
 ]
 
 // Map toolchains to compilers


### PR DESCRIPTION
* WISE-1570 and K64F-BG96 builds won't work until mbed-os 5.9 fixes are out so disabling them for now.