### PR TITLE
Removing modem_trace configurable

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,10 +1,6 @@
 {
     "config": {
         "sock-type": "TCP",
-        "modem_trace": {
-            "help": "Turns AT command trace on/off from the cellular modem, defaults to off",
-            "value": false
-        },
         "sim-pin-code": {
             "help": "SIM PIN code",
             "value": "\"1234\""


### PR DESCRIPTION
Modem_trace is no longer used because of PR  #69 