### PR TITLE
Fixed crash bug in dot_event() where interface could have been called…

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -106,13 +106,13 @@ void dot_event()
 {
     while (true) {
         Thread::wait(4000);
-        if (!iface->is_connected()) {
+        if (iface && iface->is_connected()) {
+            break;
+        } else {
             trace_mutex.lock();
             printf(".");
             fflush(stdout);
             trace_mutex.unlock();
-        } else {
-            break;
         }
     }
 }


### PR DESCRIPTION
Fixed crash in dot printing thread when iface was not created but referenced.