### PR TITLE
Cellular: Decrease main stack size from 4096 to 2048

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -90,7 +90,7 @@ static void trace_close()
 }
 #endif // #if MBED_CONF_MBED_TRACE_ENABLE
 
-Thread dot_thread(osPriorityNormal, 512);
+Thread dot_thread(osPriorityNormal, 512, NULL, "dot_thread");
 
 void print_function(const char *format, ...)
 {

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,5 +1,8 @@
 {
     "config": {
+        "main-stack-size": {
+            "value": 2048
+        },
         "sock-type": "TCP",
         "sim-pin-code": {
             "help": "SIM PIN code",


### PR DESCRIPTION
The stack size of the main thread decreased from 0x1000 to 0x800.

Fixes Arm internal ref IOTCELL-1087.