### PR TITLE
[5.10 OOB] Sim pin hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See the file `mbed_app.json` in the root directory of your application. This fil
 
 ```json
         "sim-pin-code": {
-            "help": "SIM PIN code",
+            "help": "SIM PIN code, set to 0 if none",
             "value": "\"1234\""
         },
         "apn": {

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -2,7 +2,7 @@
     "config": {
         "sock-type": "TCP",
         "sim-pin-code": {
-            "help": "SIM PIN code",
+            "help": "SIM PIN code, set to 0 if none",
             "value": "\"1234\""
         },
         "apn": {


### PR DESCRIPTION
If no SIM pin is necessary, the correct value for the config option `sim-pin-code` is `0`. I've added this hint to the help text for the config option. This is the case when using the ublox C030 with its eSIM.