### PR TITLE
Updating mbed-os to mbed-os-5.10.3

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482
+https://github.com/ARMmbed/mbed-os/#bf6f2c3c6434a6de9eb9511feffa5948b3d1f20f


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.10.3 . 