### PR TITLE
Updating mbed-os to mbed-os-5.12.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -165,7 +165,7 @@ def run_smoke(raasName, suite_to_run, toolchains, targets) {
             }
           }     
           execute("python clitest.py --suitedir mbed-clitest-suites/suites/ --suite ${suite_to_run} --type hardware --reset \
-                  --raas ${raasName}.mbedcloudtesting.com:80 --tcdir mbed-clitest-suites/cellular --raas_queue --raas_queue_timeout 3600 \
+                  --raas https://${raasName}.mbedcloudtesting.com:443 --tcdir mbed-clitest-suites/cellular --raas_queue --raas_queue_timeout 3600 \
                   --raas_share_allocs --failure_return_value -vvv -w --log log_${raasName}_${suiteName}")
           archive "log_${raasName}_${suiteName}/**/*"
         }

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#cfa7938a4dd6d1a4c501945b9c26ca68f70e284e
+https://github.com/ARMmbed/mbed-os/#73f096399b4cda1f780b140c87afad9446047432


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.12.4 . 