### PR TITLE
L496 stmod

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -33,6 +33,12 @@
             "nsapi.default-cellular-apn": 0,
             "nsapi.default-cellular-username": 0,
             "nsapi.default-cellular-password": 0
+        },
+        "DISCO_L496AG": {
+            "target.macros_add": [
+                "CELLULAR_DEVICE=STModCellular"
+            ],
+            "stmod_cellular.provide-default": "true"
         }
     }
 }

--- a/stmod_cellular.lib
+++ b/stmod_cellular.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/STMOD_CELLULAR.git/#641a5958f4bde161aaaef10dd39f4037bf25b1d8


### PR DESCRIPTION
This PR adds the stmod_cellular lib and enables it for DISCO_L496AG target.
This allows using the example with DISCO_L496AG + Quectel BG96 expansion board; also called the p-l496g-cell02 PACK. (https://www.st.com/en/evaluation-tools/p-l496g-cell02.html)

## Log when running application on p-L496-cell02 pack

mbed-os-example-cellular


Built: May 21 2019, 13:28:08


[MAIN], plmn: NULL
Establishing connection
...

Connection Established.
TCP: connected with echo.mbedcloudtesting.com server
TCP: Sent 4 Bytes to echo.mbedcloudtesting.com
Received from echo server 4 Bytes
.

Success. Exiting
