### PR TITLE
DISCO_L496AG with stmod cellular support

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -33,6 +33,13 @@
             "nsapi.default-cellular-apn": null,
             "nsapi.default-cellular-username": null,
             "nsapi.default-cellular-password": null
+        },
+        "DISCO_L496AG": {
+            "target.macros_add": [
+                "CELLULAR_DEVICE=STModCellular"
+            ],
+            "target.components_add": ["STMOD_CELLULAR"],
+            "stmod_cellular.provide-default": "true"
         }
     }
 }


### PR DESCRIPTION
This PR adds support for p-l496g-cell02 pack composed of DISCO_L496AG target and BG96 based expansion board.

See https://www.st.com/en/evaluation-tools/p-l496g-cell02.html

@MarceloSalazar @jeromecoutant
