### PR TITLE
Jenkinsfile: disable IAR build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,8 +33,7 @@ def targets = [
 // Map toolchains to compilers
 def toolchains = [
   ARM: "armcc",
-  GCC_ARM: "arm-none-eabi-gcc",
-  IAR: "iar_arm"
+  GCC_ARM: "arm-none-eabi-gcc"
   ]
 
 def stepsForParallel = [:]


### PR DESCRIPTION
Jenkinsfile: disable IAR build
- IAR disabled due to license issue