### PR TITLE
Jenkinsfile: removed dragonfly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,6 @@ def raas = [
 
 // Supported Modems
 def targets = [
-  "MTB_MTS_DRAGONFLY",
   "UBLOX_C030_U201",
   "MTB_ADV_WISE_1570",
   "NRF52840_DK",


### PR DESCRIPTION
Jenkinsfile: removed dragonfly
- Removed MTB_MTS_DRAGONFLY
- Support will be removed from mbed-os master soon
- Related mbed-os PR: https://github.com/ARMmbed/mbed-os/pull/12810