### PR TITLE
CMake: Call mbed_set_post_build API for setting post build operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,15 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.18.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
 
-# TODO: @mbed-os-tools MBED_ROOT and MBED_CONFIG_PATH should probably come from mbedtools
-set(MBED_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
 set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
 set(APP_TARGET mbed-os-example-cellular)
 
-include(${MBED_ROOT}/tools/cmake/app.cmake)
+include(${MBED_PATH}/tools/cmake/app.cmake)
 
-add_subdirectory(${MBED_ROOT})
+add_subdirectory(${MBED_PATH})
 
 add_executable(${APP_TARGET})
 
@@ -31,7 +30,7 @@ target_link_libraries(${APP_TARGET}
         mbed-cellular
 )
 
-mbed_generate_bin_hex(${APP_TARGET})
+mbed_set_post_build(${APP_TARGET})
 
 option(VERBOSE_BUILD "Have a verbose build process")
 if(VERBOSE_BUILD)


### PR DESCRIPTION
- Updated CMakeLists.txt file to call mbed_set_post_build API for setting post-build operations

@0xc0170 @hugueskamba 