### PR TITLE
Update mbed-os to its development branch

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#f2278567d09b9ae9f4843e1d9d393526b9462783
+https://github.com/ARMmbed/mbed-os/


### PR DESCRIPTION
Update the Mbed OS version pointed at by this example's development branch to the Mbed OS development branch. This ensures that the development branch will build using the latest mbed-os after a checkout and deploy.

This may look like a duplicate, as we merged something very similar previously. However, the Mbed OS 6.5.0 release updated this mbed-os.lib file after our previous merge, so we need to update the file again. The release scripts are updated not to do this in the future.