### PR TITLE
Update for mbed-os-6.13.0

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#cecc47b4a53951527dd3f670465c8566396ad101
+https://github.com/ARMmbed/mbed-os/#d147abc3e556c58e5e343d34b729bc2192e18bd3


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.13.0 release of mbed-os. 