### PR TITLE
Update for mbed-os-6.14.0

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#d147abc3e556c58e5e343d34b729bc2192e18bd3
+https://github.com/ARMmbed/mbed-os/#3377f083b3a6bd7a1b45ed2cea5cf083b9007527


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.14.0 release of mbed-os. 