### PR TITLE
[BUGFIX] assigns the return value of _socket.close() to ret

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -119,7 +119,7 @@ private:
             printf("Received from echo server %d Bytes\n", ret);
         }
 
-        _socket.close();
+        ret = _socket.close();
 
         if (ret != NSAPI_ERROR_OK) {
             printf("%sSocket.close() fails, code: %d\n", SOCKET_TYPE, ret);


### PR DESCRIPTION
Assigns the return value of `_socket.close()` to `ret`, otherwise, it would be always be the number of bytes returned and this would trigger the the error message `printf("%sSocket.close() fails, code: %d\n", SOCKET_TYPE, ret);`. 